### PR TITLE
Update assign spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+/.elixir_ls

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-
-/.elixir_ls

--- a/lib/bamboo/eex.ex
+++ b/lib/bamboo/eex.ex
@@ -71,7 +71,7 @@ defmodule Bamboo.EEx do
   @doc """
   Assigns a value to a key in an email.
   """
-  @spec assign(Bamboo.Email.t, atom, atom) :: Bamboo.Email.t
+  @spec assign(Bamboo.Email.t, atom, any) :: Bamboo.Email.t
   def assign(%{ assigns: assigns } = email, key, value) do
     %{ email | assigns: Map.put(assigns, key, value) }
   end


### PR DESCRIPTION
The current spec for `assign/3` is to only allow `atom` for `value`. This obviously causes Dialyzer to complain when trying to assign anything other than an atom.

This PR sets the spec to `any` for `value`.